### PR TITLE
correct action number for screenshot in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ button config default
 10 = backlight min max  
 11 = remount /mnt as rw  
 12 = remount /mnt as ro  
-12 = screenshot using fbgrab
+13 = screenshot using fbgrab  
 20 = kill, sync and shutdown  
 21 = kill. Does not work on most emulators. do not use  


### PR DESCRIPTION
This corrects the screenshot action number from 12 to 13. See:

https://github.com/MiyooCFW/daemon/blob/39e83f57fc8ad6f95684a3b3960760d74451a880/main.c#L502-L504

I also fixed the line break between 13 and 20.