### PR TITLE
Set up daemon ci build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,33 @@
+# based on https://github.com/MiyooCFW/gmenunx/blob/master/.github/workflows/c-cpp.yml
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:   
+  build-modern:
+    name: daemon for MiyooCFW 1.4+ (musl libc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make
+    - uses: actions/upload-artifact@v2
+      with:
+        path: daemon
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+  build-legacy:
+    name: legacy daemon for Miyoo <=1.3.3 (uClibc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:steward
+    steps:
+    - uses: actions/checkout@v2
+    - name: build
+      run: make
+    - uses: actions/upload-artifact@v2
+      with:
+        name: legacy daemon
+        path: daemon
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -15,6 +15,7 @@ jobs:
       run: make
     - uses: actions/upload-artifact@v2
       with:
+        name: miyoo_daemon
         path: daemon
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
   build-legacy:
@@ -28,6 +29,6 @@ jobs:
       run: make
     - uses: actions/upload-artifact@v2
       with:
-        name: legacy daemon
+        name: legacy miyoo_daemon
         path: daemon
         if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all:
-	arm-linux-gcc main.c -o daemon -ggdb -lSDL
+	arm-linux-gcc main.c -o daemon -ggdb -lSDL -lc
 clean:
 	rm -rf daemon


### PR DESCRIPTION
I set up a CI build for uClibc and musl, similar to the others. I had to add `-lc` to the compile command, apparently because of us having musl as a static toolchain but not wanting to add `-static` to the compile command, but now it builds on both toolchains.