### PR TITLE
add hotkey_custom flag from ioctl + scripts rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Remember: all hotkeys will work only in combination with RESET/HOME button (see 
 | Up | Volume Up |
 | Start | Screenshot |
 | Select | Force-close app |
+| L2 | Soft-close app |
+| R2 | Quick shutdown |
 
 ## Config
 - custom hotkeys config location  
@@ -25,7 +27,7 @@ Remember: all hotkeys will work only in combination with RESET/HOME button (see 
 - hotkeys config format  
 `x:a:y:b:up:down:left:right:select:start:l2:r2:hold-x:hold-a:hold-y:hold-b:hold-up:hold-down:hold-left:hold-right:hold-select:hold-start:hold-l2:hold-r2`  
 - default hotkeys config values and format (the string must match exactly)
-`0:0:0:0:3:4:2:1:22:13:0:0:0:0:0:0:0:0:0:0:0:0:0:0`  
+`0:0:0:0:3:4:2:1:22:13:23:20:0:0:0:0:0:0:0:0:0:0:0:0`  
 **NOTE**: 
 - when enabling custom hotkeys an existing ones will be disabled&overwritten by above defaults or any passed by user. However that doesn't apply to hardcoded ones like emulating L1/R1 or other additional buttons.
 - you can disable/enable custom hotkey bindings in `/mnt/options.cfg` with  HOTKEY_CUSTOM=0 or 1 entry
@@ -45,7 +47,7 @@ Remember: all hotkeys will work only in combination with RESET/HOME button (see 
 11 = remount /mnt as rw  
 12 = remount /mnt as ro  
 13 = screenshot using fbgrab  
-20 = kill, sync and shutdown  
+20 = kill, sync and shutdown (quick shutdown)
 21 = kill gui. Does not work on most apps. do not use  
 22 = kill force app. Work on most apps.
 23 = kill soft app. Work on a few apps, guaranties proper closing.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ default: 3550
 
 ## Default Button Mappings
 
+Remember: all hotkeys will work only in combination with RESET/HOME button (see kernel's miyoo_kbd.c code)
+
 | BUTTON | ACTION |
 |  --- | --- |
 | Right | Brightness Up |
@@ -15,15 +17,17 @@ default: 3550
 | Down | Volume Down |
 | Up | Volume Up |
 | Start | Screenshot |
-| Hold Select | Quick Shutdown |
+| Select | Force-close app |
 
 ## Config
+**WARNING**: custom hotkeys defined here will only work when below file exist:  
 button config location  
 `/mnt/.buttons.conf`  
 button config format  
-`x:a:y:b:up:down:left:right:select:start:hold-x:hold-a:hold-y:hold-b:hold-up:hold-down:hold-left:hold-right:hold-select:hold-start`  
-button config default  
-`0:0:0:0:3:4:2:1:0:13:0:0:0:0:0:0:0:0:21:0` 
+`x:a:y:b:up:down:left:right:select:start:l2:r2:hold-x:hold-a:hold-y:hold-b:hold-up:hold-down:hold-left:hold-right:hold-select:hold-start:hold-l2:hold-r2`  
+button config file default values  
+`0:0:0:0:3:4:2:1:22:13:0:0:0:0:0:0:0:0:0:0:0:0:0:0`  
+<u>NOTE</u>: When enabling custom hotkeys an existing ones will be disable&overwritten by above defaults or any passed by user. However that doesn't apply to hardcoded ones like emulating L1/R1 or other additional buttons.
 
 ## Actions
 1 = backlight up  
@@ -40,4 +44,6 @@ button config default
 12 = remount /mnt as ro  
 13 = screenshot using fbgrab  
 20 = kill, sync and shutdown  
-21 = kill. Does not work on most emulators. do not use  
+21 = kill gui. Does not work on most apps. do not use  
+22 = kill force app. Work on most apps.
+23 = kill soft app. Work on a few apps, guaranties proper closing.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ Remember: all hotkeys will work only in combination with RESET/HOME button (see 
 | Select | Force-close app |
 
 ## Config
-**WARNING**: custom hotkeys defined here will only work when below file exist:  
-button config location  
+- custom hotkeys config location  
 `/mnt/.buttons.conf`  
-button config format  
+- hotkeys config format  
 `x:a:y:b:up:down:left:right:select:start:l2:r2:hold-x:hold-a:hold-y:hold-b:hold-up:hold-down:hold-left:hold-right:hold-select:hold-start:hold-l2:hold-r2`  
-button config file default values  
+- default hotkeys config values and format (the string must match exactly)
 `0:0:0:0:3:4:2:1:22:13:0:0:0:0:0:0:0:0:0:0:0:0:0:0`  
-<u>NOTE</u>: When enabling custom hotkeys an existing ones will be disable&overwritten by above defaults or any passed by user. However that doesn't apply to hardcoded ones like emulating L1/R1 or other additional buttons.
+**NOTE**: 
+- when enabling custom hotkeys an existing ones will be disabled&overwritten by above defaults or any passed by user. However that doesn't apply to hardcoded ones like emulating L1/R1 or other additional buttons.
+- you can disable/enable custom hotkey bindings in `/mnt/options.cfg` with  HOTKEY_CUSTOM=0 or 1 entry
+- when there's no custom hotkeys config file and HOTKEY_CUSTOM=1 then above default hotkeys apply across device
 
 ## Actions
 1 = backlight up  

--- a/main.c
+++ b/main.c
@@ -510,14 +510,14 @@ int main(int argc, char** argv)
           system("mount -o remount,ro,utf8 /dev/mmcblk0p4");
           break;
       case 13:
-          system("sh -c mkdir - p /mnt/screenshots ; name=/mnt/screenshots/system ; if test -e $name.png ; then i=1 ; while test -e $name-$i.png ; do i=$((i+1)) ; done; name=\"$name-$i\" ; fi ; /usr/bin/fbgrab \"$name\".png");
+          system("sh -c mkdir - p /mnt/screenshots ; name=/mnt/screenshots/system ; if test -e $name.png ; then i=1 ; while test -e $name-$i.png ; do i=$((i+1)) ; done; name=\"$name-$i\" ; fi ; fbgrab \"$name\".png");
           break;
       case 20:
         {
           int status;
           pid_t son = fork();
           if (!son) {
-            execlp("sh", "sh", "-c", "kill $(ps -al | grep \"/mnt/\" | grep -v \"/kernel/\" | tr -s [:blank:] | cut -d \" \" -f 2) ; sleep 0.1 ; sync && poweroff",  NULL);
+            execlp("sh", "sh", "-c", "kill -9 $(ps -al | grep \"/mnt/\" | grep -v \"/kernel/\" | tr -s [:blank:] | cut -d \" \" -f 2) ; sleep 0.1 ; sync && swapoff -a && poweroff",  NULL);
           }
           break;
 	        }

--- a/main.c
+++ b/main.c
@@ -249,7 +249,7 @@ int main(int argc, char** argv)
   char lstr[256];
   int battery_level;
   int hotkeys_enabled=-1;
-  int hotkey_custom=0;
+  int hotkey_custom=1;
   setvbuf (stdout, NULL, _IONBF, 0);
 
   create_daemon();
@@ -287,11 +287,11 @@ int main(int argc, char** argv)
   options_file = fopen(MIYOO_OPTIONS_FILE, "r");
   if (options_file != NULL) {
     while (fgets(lstr, sizeof(lstr), options_file)) {
-      if (strcmp(lstr, "HOTKEY_CUSTOM=1") == 0) {
+      if (strcmp(lstr, "HOTKEY_CUSTOM=1\n") == 0) {
         hotkeys_enabled = 1;
         //printf("%s\n", lstr);
         break;
-      } else if (strcmp(lstr, "HOTKEY_CUSTOM=0") == 0) {
+      } else if (strcmp(lstr, "HOTKEY_CUSTOM=0\n") == 0) {
         hotkeys_enabled = 0;
         //printf("%s\n", lstr);
         break;
@@ -394,8 +394,9 @@ int main(int argc, char** argv)
 	  ;
 	  break;
       case 1:
-
         //printf("backlight++\n");
+        lid = read_conf(MIYOO_LID_CONF, 5);
+        sleep(0.1);
         if(lid < 10){
           lid+= 1;
           write_conf(MIYOO_LID_FILE, lid);
@@ -408,6 +409,8 @@ int main(int argc, char** argv)
         break;
       case 2:
         //printf("backlight--\n");
+        lid = read_conf(MIYOO_LID_CONF, 5);
+        sleep(0.1);
         if(lid > 1){
           lid-= 1;
           write_conf(MIYOO_LID_FILE, lid);
@@ -418,6 +421,8 @@ int main(int argc, char** argv)
         break;
       case 3:
         //printf("sound++\n");
+        vol = read_conf(MIYOO_VOL_FILE,5);
+        sleep(0.1);
         if(vol < 9){
           vol+= 1;
           write_conf(MIYOO_VOL_FILE, vol);
@@ -427,6 +432,8 @@ int main(int argc, char** argv)
         break;
       case 4:
         //printf("sound--\n");
+        vol = read_conf(MIYOO_VOL_FILE,5);
+        sleep(0.1);
         if(vol > 0){
           vol-= 1;
           write_conf(MIYOO_VOL_FILE, vol);
@@ -436,6 +443,8 @@ int main(int argc, char** argv)
         break;
       case 5:
         //printf("mute\n");
+        vol = read_conf(MIYOO_VOL_FILE,5);
+        sleep(0.1);
         if(vol == 0){
           vol = read_conf(MIYOO_VOL_FILE,5);
           if(vol < 1){
@@ -449,7 +458,9 @@ int main(int argc, char** argv)
         }
         break;
       case 6: 
-        //printf("volume rotate up\n"); 
+        //printf("volume rotate up\n");
+        vol = read_conf(MIYOO_VOL_FILE,5);
+        sleep(0.1);
         if(vol < 9){ 
           vol+= 1;
           write_conf(MIYOO_VOL_FILE, vol);
@@ -464,6 +475,8 @@ int main(int argc, char** argv)
         break;
       case 7: 
         //printf("volume rotate down\n"); 
+        vol = read_conf(MIYOO_VOL_FILE,5);
+        sleep(0.1);
         if(vol < 1){ 
           vol = 9;
           write_conf(MIYOO_VOL_FILE, vol);
@@ -478,6 +491,8 @@ int main(int argc, char** argv)
         break;
       case 8: 
         //printf("backlight rotate up\n"); 
+        lid = read_conf(MIYOO_LID_CONF, 5);
+        sleep(0.1);
         if(lid < 10){ 
           lid+= 1; 
           write_conf(MIYOO_LID_FILE, lid); 
@@ -494,6 +509,8 @@ int main(int argc, char** argv)
         break;
       case 9: 
         //printf("backlight rotate down\n"); 
+        lid = read_conf(MIYOO_LID_CONF, 5);
+        sleep(0.1);
         if(lid == 1){ 
           lid = 10; 
           write_conf(MIYOO_LID_FILE, lid); 
@@ -510,6 +527,8 @@ int main(int argc, char** argv)
         break;
       case 10: 
         //printf("backlight min max\n"); 
+        lid = read_conf(MIYOO_LID_CONF, 5);
+        sleep(0.1);
         if(lid != 10){ 
           lid = 10; 
           write_conf(MIYOO_LID_FILE, lid); 

--- a/main.c
+++ b/main.c
@@ -52,9 +52,7 @@
 
 #define BUTTON_COUNT	12
 
-unsigned char actionmap[BUTTON_COUNT*2]={0,0,0,0,3,4,2,1,22,13,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-int hotkey_custom = 1;
-
+unsigned char actionmap[BUTTON_COUNT*2]={0,0,0,0,3,4,2,1,22,13,23,20,0,0,0,0,0,0,0,0,0,0,0,0};
 
 static void create_daemon(void)
 {
@@ -250,7 +248,8 @@ int main(int argc, char** argv)
   char wstr[100];
   char lstr[256];
   int battery_level;
-  int hotkeys_enabled = -1;
+  int hotkeys_enabled=-1;
+  int hotkey_custom=0;
   setvbuf (stdout, NULL, _IONBF, 0);
 
   create_daemon();
@@ -301,7 +300,6 @@ int main(int argc, char** argv)
     fclose(options_file);
   } else {
   //  printf("Could not open the OPTIONS file.\n");
-    return 1;
   }
 
   //check if button file exist for custom hotkeys to apply or either entry in options file to accept default hotkeys.
@@ -526,7 +524,7 @@ int main(int argc, char** argv)
           info_fb0(fb0, lid, vol, 1); 
         } 
   	break ;
-   	case 11:
+      case 11:
       	  system("mount -o remount,rw,utf8 /dev/mmcblk0p4");
           break;
       case 12:
@@ -537,6 +535,7 @@ int main(int argc, char** argv)
           break;
       case 20:
         {
+          //printf("quick shutdown\n"); 
           int status;
           pid_t son = fork();
           if (!son) {
@@ -546,7 +545,7 @@ int main(int argc, char** argv)
 	        }
       case 21:
         {
-          //printf("kill\n"); 
+          //printf("kill GUI\n"); 
           int status;
           pid_t son = fork();
           if (!son) {
@@ -557,22 +556,20 @@ int main(int argc, char** argv)
         }
       case 22:
         {
-          //printf("kill\n"); 
+          //printf("kill force\n"); 
           int status;
           pid_t son = fork();
           if (!son) {
-            //execlp("sh", "sh", "/mnt/kernel/killgui.sh", NULL);
             execlp("sh", "sh", "-c", "/bin/kill -9 $(/bin/ps -al | /bin/grep \"/mnt/\")",  NULL);
           }
           break; 
         }
       case 23:
         {
-          //printf("kill\n"); 
+          //printf("kill soft\n"); 
           int status;
           pid_t son = fork();
           if (!son) {
-            //execlp("sh", "sh", "/mnt/kernel/killgui.sh", NULL);
             execlp("sh", "sh", "-c", "/bin/kill -2 $(/bin/ps -al | /bin/grep \"/mnt/\")",  NULL);
           }
           break; 

--- a/main.c
+++ b/main.c
@@ -33,6 +33,7 @@
 #define MIYOO_VIR_SET_VER     _IOWR(0x101, 0, unsigned long)
 #define MIYOO_SND_SET_VOLUME  _IOWR(0x100, 0, unsigned long)
 #define MIYOO_KBD_GET_HOTKEY  _IOWR(0x100, 0, unsigned long)
+#define MIYOO_KBD_SET_HOTKEY  _IOWR(0x106, 0, unsigned long)
 #define MIYOO_KBD_SET_VER     _IOWR(0x101, 0, unsigned long)
 #define MIYOO_FB0_PUT_OSD     _IOWR(0x100, 0, unsigned long)
 #define MIYOO_FB0_SET_MODE    _IOWR(0x101, 0, unsigned long)
@@ -45,12 +46,13 @@
 #define MIYOO_VOL_FILE        "/mnt/.volume.conf"
 #define MIYOO_LID_CONF        "/sys/devices/platform/backlight/backlight/backlight/brightness"
 #define MIYOO_BUTTON_FILE     "/mnt/.buttons.conf"
-#define MIYOO_BATTERY    "/sys/class/power_supply/miyoo-battery/voltage_now"
+#define MIYOO_BATTERY         "/sys/class/power_supply/miyoo-battery/voltage_now"
 #define MIYOO_BATTERY_FILE    "/mnt/.batterylow.conf"
 
-#define BUTTON_COUNT	10
+#define BUTTON_COUNT	12
 
-unsigned char actionmap[BUTTON_COUNT*2]={0,0,0,0,3,4,2,1,0,13,0,0,0,0,0,0,0,0,20,0};
+unsigned char actionmap[BUTTON_COUNT*2]={0,0,0,0,3,4,2,1,22,13,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+int hotkey_custom = 1;
 
 
 static void create_daemon(void)
@@ -240,7 +242,7 @@ int main(int argc, char** argv)
   int lid=0, vol=0, fbp=0;
   char buf[255]={0};
   unsigned long ret, lastret, version;
-  int fb0, kbd, snd, vir;
+  int fb0, kbd, snd, vir, fd;
   int battery_low=3550;
   FILE *battery_file;
   char wstr[100];
@@ -278,7 +280,15 @@ int main(int argc, char** argv)
   // buttons
   read_button_config(MIYOO_BUTTON_FILE,actionmap);
   signal(SIGUSR1, my_handler);
-
+  
+  //check if .buttons.conf file exist for custom hotkeys to overwrite kernel's bindings
+  fd = open(MIYOO_BUTTON_FILE, O_RDWR);
+  if(fd < 0){
+    hotkey_custom = 0;
+  }
+  ioctl(kbd, MIYOO_KBD_SET_HOTKEY, hotkey_custom);
+  close(fd);
+  
   // info fb0
   info_fb0(fb0, lid, vol, 0);
 
@@ -500,7 +510,7 @@ int main(int argc, char** argv)
           system("mount -o remount,ro,utf8 /dev/mmcblk0p4");
           break;
       case 13:
-          system("sh -c /mnt/apps/fbgrab/screenshot.sh");
+          system("sh -c mkdir - p /mnt/screenshots ; name=/mnt/screenshots/system ; if test -e $name.png ; then i=1 ; while test -e $name-$i.png ; do i=$((i+1)) ; done; name=\"$name-$i\" ; fi ; /usr/bin/fbgrab \"$name\".png");
           break;
       case 20:
         {
@@ -519,6 +529,28 @@ int main(int argc, char** argv)
           if (!son) {
             //execlp("sh", "sh", "/mnt/kernel/killgui.sh", NULL);
             execlp("sh", "sh", "-c", "kill $(ps -al | grep \"/mnt/\" | grep -v \"/kernel/\" | tr -s [:blank:] | cut -d \" \" -f 2)",  NULL);
+          }
+          break; 
+        }
+      case 22:
+        {
+          //printf("kill\n"); 
+          int status;
+          pid_t son = fork();
+          if (!son) {
+            //execlp("sh", "sh", "/mnt/kernel/killgui.sh", NULL);
+            execlp("sh", "sh", "-c", "/bin/kill -9 $(/bin/ps -al | /bin/grep \"/mnt/\")",  NULL);
+          }
+          break; 
+        }
+      case 23:
+        {
+          //printf("kill\n"); 
+          int status;
+          pid_t son = fork();
+          if (!son) {
+            //execlp("sh", "sh", "/mnt/kernel/killgui.sh", NULL);
+            execlp("sh", "sh", "-c", "/bin/kill -2 $(/bin/ps -al | /bin/grep \"/mnt/\")",  NULL);
           }
           break; 
         }


### PR DESCRIPTION
- use MIYOO_KBD_SET_HOTKEY
- change default hotkey bindings to be inline with kernel's one
- restore LR/R2 setting
- update screenshots script
- update poweroff script
- add 22 & 23 kill actions
- use `/mnt/options.cfg` with HOTKEY_CUSTOM=0/1 to disable/enable daemon`s custom or default hotkeys